### PR TITLE
docs: replace DES-EDE3-CBC with AES-256-CBC in PEM examples (fix #28665)

### DIFF
--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -443,7 +443,7 @@ the function.
 
 The pseudo code to derive the key would look similar to:
 
- EVP_CIPHER* cipher = EVP_des_ede3_cbc();
+ EVP_CIPHER* cipher = EVP_aes_256_cbc();
  EVP_MD* md = EVP_md5();
 
  unsigned int nkey = EVP_CIPHER_get_key_length(cipher);
@@ -518,13 +518,13 @@ Write a certificate to a BIO:
 Write a private key (using traditional format) to a BIO using
 triple DES encryption, the pass phrase is prompted for:
 
- if (!PEM_write_bio_PrivateKey(bp, key, EVP_des_ede3_cbc(), NULL, 0, 0, NULL))
+ if (!PEM_write_bio_PrivateKey(bp, key, EVP_aes_256_cbc(), NULL, 0, 0, NULL))
      /* Error */
 
-Write a private key (using PKCS#8 format) to a BIO using triple
-DES encryption, using the pass phrase "hello":
+Write a private key (using PKCS#8 format) to a BIO using
+AES-256-CBC encryption, using the pass phrase "hello":
 
- if (!PEM_write_bio_PKCS8PrivateKey(bp, key, EVP_des_ede3_cbc(),
+ if (!PEM_write_bio_PKCS8PrivateKey(bp, key, EVP_aes_256_cbc(),
                                     NULL, 0, 0, "hello"))
      /* Error */
 


### PR DESCRIPTION
A colleague of mine got confused today having a look at https://docs.openssl.org/3.6/man3/PEM_read_bio_PrivateKey/#examples
which still uses DES-EDE3-CBC / EVP_des_ede3_cbc() four times in its examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Updated private key encryption examples to use AES‑256‑CBC instead of 3DES for stronger, modern defaults.
  * Unified descriptive text to refer to AES‑256‑CBC encryption throughout examples and guidance.
  * Clarified passphrase and option usage in examples to reduce ambiguity when choosing encryption settings.
  * Confirmed no functional, API, or behavioral changes; documentation-only update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->